### PR TITLE
I think we should just be using the normal connector again

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,13 +44,7 @@ export default function Header({ address, isConnected }: Props) {
         <>
           <button
             className="primary-button"
-            onClick={async () => {
-              const wallet = await sequence.initWallet("mumbai");
-              const connectDetails = await wallet.connect({
-                app: "Glo Wallet",
-                askForEmail: true,
-              });
-            }}
+            onClick={() => connect({ connector: connectors[0] })}
           >
             Social
           </button>


### PR DESCRIPTION
Calling it directly creates weird breaking functionality, and somehow force connects on mainnet instead of on testnet on local. For me the email cookie is still populated, but that _might_ be because it's been requested before with this user? 
If we do need to askForEmail we should probably do it straight within the connect method somehow instead.