### PR TITLE
In collapsed mode - don't show no transactions yet when there actually are transactions

### DIFF
--- a/components/Transactions.tsx
+++ b/components/Transactions.tsx
@@ -90,7 +90,7 @@ export default function Transactions() {
             </div>
           )}
 
-          {isConnected && (
+          {isConnected && !transfers.length && (
             <div className="mt-6">
               <span> No transactions yet - </span>
               <button


### PR DESCRIPTION
Resolves #93 