### PR TITLE
hotfix/responsive login modal

### DIFF
--- a/components/Modals/BuyGloModal.tsx
+++ b/components/Modals/BuyGloModal.tsx
@@ -29,7 +29,7 @@ export default function BuyGloModal() {
   }
 
   return (
-    <div className="flex flex-col max-w-[343px]">
+    <div className="modal-body flex flex-col max-w-[343px]">
       <Holdings glo={glo} setGlo={setGlo} yearlyYield={yearlyYield} />
       <DetailedEnoughToBuy yearlyYield={yearlyYield} glo={glo} />
       <button

--- a/components/Modals/UserAuthModal.tsx
+++ b/components/Modals/UserAuthModal.tsx
@@ -50,14 +50,14 @@ export default function UserAuthModal() {
 
   return (
     <>
-      <section className="p-8 flex flex-col items-center">
-        <Image
-          className="absolute top-[-50px] border-2 rounded-full border-cyan-600"
-          src="/jeff.svg"
-          alt="glo logo"
-          width={100}
-          height={100}
-        />
+      <Image
+        className="jeffs-floating-head"
+        src="/jeff.svg"
+        alt="glo logo"
+        width={100}
+        height={100}
+      />
+      <section className="sticky p-8 flex flex-col items-center">
         <h1 className="">👋 Hey it’s Jeff</h1>
         <p className="copy text-xl">
           Thanks for being part of the Glo movement!

--- a/components/Modals/UserAuthModal.tsx
+++ b/components/Modals/UserAuthModal.tsx
@@ -52,7 +52,7 @@ export default function UserAuthModal() {
     <>
       <section className="p-8 flex flex-col items-center">
         <Image
-          className="border-2 rounded-full border-cyan-600"
+          className="absolute top-[-50px] border-2 rounded-full border-cyan-600"
           src="/jeff.svg"
           alt="glo logo"
           width={100}
@@ -63,7 +63,7 @@ export default function UserAuthModal() {
           Thanks for being part of the Glo movement!
         </p>
       </section>
-      <section className="p-8 rounded-b-3xl bg-pine-100 after:bg-pine-100">
+      <section className="modal-body p-8 rounded-b-3xl bg-pine-100 after:bg-pine-100">
         <h2 className="flex justify-center">Sign up</h2>
         <div>
           <div className="p-0 form-group flex justify-center">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -121,7 +121,7 @@ export default function App({ Component, pageProps }: AppProps) {
           <WagmiConfig config={config}>
             <ModalContext.Provider value={{ openModal, closeModal }}>
               <Component {...pageProps} />
-              <dialog className="modal" ref={dialogRef}>
+              <dialog ref={dialogRef}>
                 <div ref={contentRef}>{modalContent}</div>
               </dialog>
             </ModalContext.Provider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,6 +30,10 @@ body {
   label {
     @apply font-black mr-4;
   }
+
+  dialog {
+    @apply overflow-visible rounded-3xl p-0 max-h-[80vh];
+  }
 }
 
 @layer components {
@@ -57,8 +61,8 @@ body {
     @apply border flex justify-between rounded-lg bg-pine-100 border-pine-400 p-2;
   }
 
-  .modal {
-    @apply rounded-3xl p-0;
+  .modal-body {
+    @apply overflow-y-auto;
   }
 
   .form-group {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@ body {
   }
 
   dialog {
-    @apply overflow-visible rounded-3xl p-0 max-h-[80vh];
+    @apply rounded-3xl p-0 max-h-[80vh];
   }
 }
 
@@ -79,5 +79,13 @@ body {
 
   .cta-icon {
     @apply mr-4 flex border justify-center min-w-[32px] min-h-[32px] rounded-full bg-pine-200;
+  }
+
+  .jeffs-floating-head {
+    @apply z-50 fixed left-[37vw] top-[2vh] border-2 rounded-full border-cyan-600
+    min-[400px]:top-[6vh] min-[400px]:left-[39vw]
+    md:top-[12vh] md:left-[44vw]
+    lg:top-[8vh] lg:left-[46vw]
+    2xl:left-[47.67vw];
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -82,7 +82,7 @@ body {
   }
 
   .jeffs-floating-head {
-    @apply z-50 fixed left-[37vw] top-[2vh] border-2 rounded-full border-cyan-600
+    @apply z-50 fixed left-[38vw] top-[2vh] border-2 rounded-full border-cyan-600
     min-[400px]:top-[6vh] min-[400px]:left-[39vw]
     md:top-[12vh] md:left-[44vw]
     lg:top-[8vh] lg:left-[46vw]


### PR DESCRIPTION
make jeffs head whole again

styling is now only scoped to the floating image element itself so should be contained

supports all mobile devices in devtools, incomplete tablet support (TBD)

<img width="546" alt="Screen Shot 2023-06-15 at 11 12 51 PM" src="https://github.com/Glo-Foundation/glo-wallet/assets/6061507/cc9fcf0f-6ef2-4fff-a681-108474f92352">
<img width="649" alt="Screen Shot 2023-06-15 at 11 13 26 PM" src="https://github.com/Glo-Foundation/glo-wallet/assets/6061507/8fae64c6-d6b7-44e7-9316-2c9fe0c07363">
<img width="573" alt="Screen Shot 2023-06-15 at 11 13 15 PM" src="https://github.com/Glo-Foundation/glo-wallet/assets/6061507/83342485-b933-400f-8a53-45f93835b68e">
<img width="541" alt="Screen Shot 2023-06-15 at 11 13 06 PM" src="https://github.com/Glo-Foundation/glo-wallet/assets/6061507/62fb2ccf-701c-4ba8-ad7e-fe19abbfc866">
