### PR TITLE
On click of the impact on your balance overview, open buy Glo modal

### DIFF
--- a/components/Balance.tsx
+++ b/components/Balance.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useAccount } from "wagmi";
 
+import BuyGloModal from "@/components/Modals/BuyGloModal";
+import { ModalContext } from "@/lib/context";
 import { getTotalYield } from "@/utils";
 
 import Actions from "./Actions";
@@ -15,6 +17,7 @@ export default function Balance({
   balance = { formatted: "0", value: 0 },
 }: Props) {
   const { isConnected } = useAccount();
+  const { openModal } = useContext(ModalContext);
 
   // ethers and typescript don't like each other
   const illFormatMyOwnEther = Number(balance.formatted);
@@ -45,8 +48,12 @@ export default function Balance({
         </div>
       </div>
       {isConnected && <Actions />}
-      <div className="flex flex-col bg-impact-bg text-impact-fg rounded-[24px] mx-1 mb-1 px-5 pb-3">
-        <div className="overflow-hidden">
+
+      <button
+        className="flex flex-col bg-impact-bg text-impact-fg rounded-[24px] mx-1 mb-1 px-5 pb-3 w-full font-normal items-baseline"
+        onClick={() => openModal(<BuyGloModal />)}
+      >
+        <div className="">
           <div className="h-4 w-4 bg-white -rotate-45 transform origin-top-left translate-x-32"></div>
         </div>
         <div className="flex w-full justify-between items-center space-y-2">
@@ -62,7 +69,7 @@ export default function Balance({
           </div>
           <EnoughToBuy yearlyYield={yearlyYield} />
         </div>
-      </div>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Entire cyan bar in balance is now clickable

<img width="449" alt="image" src="https://github.com/Glo-Foundation/glo-wallet/assets/1226415/1a7da54d-bb4f-4688-bbea-c9d70da1bb9c">
