### PR TITLE
feature/flashy animation

### DIFF
--- a/components/Balance.tsx
+++ b/components/Balance.tsx
@@ -7,7 +7,7 @@ import { ModalContext } from "@/lib/context";
 import { getTotalYield } from "@/utils";
 
 import Actions from "./Actions";
-import EnoughToBuy from "./EnoughToBuy";
+import ImpactInset from "./ImpactInset";
 
 type Props = {
   balance: any;
@@ -49,29 +49,11 @@ export default function Balance({
         </div>
       </div>
       {isConnected && <Actions />}
-      <div className="m-1">
-        <button
-          className="flex flex-col bg-impact-bg text-impact-fg rounded-[24px] px-5 pb-3 w-full font-normal items-baseline"
-          onClick={() => openModal(<BuyGloModal />)}
-        >
-          <div className="">
-            <div className="h-4 w-4 bg-white -rotate-45 transform origin-top-left translate-x-32"></div>
-          </div>
-          <div className="flex w-full justify-between items-center space-y-2">
-            <div className="flex items-center">
-              <Image
-                className="pb-[2px] mr-2"
-                src="/glo-logo.svg"
-                alt="glo"
-                height={28}
-                width={28}
-              />
-              {yearlyYieldFormatted} / year
-            </div>
-            <EnoughToBuy yearlyYield={yearlyYield} />
-          </div>
-        </button>
-      </div>
+      <ImpactInset
+        openModal={openModal}
+        yearlyYield={yearlyYield}
+        yearlyYieldFormatted={yearlyYieldFormatted}
+      />
     </div>
   );
 }

--- a/components/CTA.tsx
+++ b/components/CTA.tsx
@@ -128,7 +128,7 @@ export default function CTA({ balance }: { balance?: string }) {
   };
 
   return (
-    <div className="bg-pine-50 rounded-[20px] p-6 transition-all">
+    <div className="bg-pine-50 rounded-[20px] p-6">
       <div className="flex justify-between cursor-default">
         <h3>🌟 Help Grow Glo!</h3>
       </div>

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,9 +1,14 @@
-import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
+import {
+  getImpactItems,
+  getImpactItemList,
+  isLiftPersonOutOfPovertyImpactItem,
+} from "@/utils";
 
 type Props = {
   yearlyYield: number;
 };
 export default function EnoughToBuy({ yearlyYield }: Props) {
+  const impactItem = getImpactItemList();
   const yearlyImpactItem = getImpactItems(yearlyYield)[0];
   const enoughToLiftPersonOutOfPoverty =
     yearlyImpactItem && isLiftPersonOutOfPovertyImpactItem(yearlyImpactItem);

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -17,13 +17,13 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const impactItemOffset = (yearlyImpactItems.length - 1) * -24;
   const [scope, animate] = useAnimate();
   const { isConnected } = useAccount();
+  const animation = async () => {
+    await animate("ul", { opacity: 1 }, { duration: 1 });
+    animate("ul", { y: "0px" }, { duration: 1.5, ease: "easeInOut" });
+  };
 
   useEffect(() => {
     if (isConnected) {
-      const animation = async () => {
-        await animate("ul", { opacity: 1 }, { duration: 1 });
-        animate("ul", { y: "0px" }, { duration: 1.5, ease: "easeInOut" });
-      };
       animation();
     }
   }, [isConnected]);

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -30,7 +30,7 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
         opacity: "1",
         transform: "translateY(0px)",
       });
-    }, 1500);
+    }, 1800);
 
     return () => {
       clearTimeout(fadeinTimer);

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -17,8 +17,14 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
     ));
 
   return (
-    <ul className="animated-impact-list">
-      {renderImpactItemList(yearlyImpactItems)}
-    </ul>
+    <div className="animated-impact-list">
+      <ul
+        style={{
+          transform: `translateY(-${(yearlyImpactItems.length - 1) * 24}px)`,
+        }}
+      >
+        {renderImpactItemList(yearlyImpactItems)}
+      </ul>
+    </div>
   );
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -21,8 +21,8 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   useEffect(() => {
     if (isConnected) {
       const animation = async () => {
-        await animate("ul", { opacity: 1 }, { duration: 1, delay: 0.5 });
-        animate("ul", { y: "0px" }, { duration: 1 });
+        await animate("ul", { opacity: 1 }, { duration: 1 });
+        animate("ul", { y: "0px" }, { duration: 1.5, ease: "easeInOut" });
       };
       animation();
     }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useAccount } from "wagmi";
 
 import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
 
@@ -12,31 +13,40 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const enoughToLiftPersonOutOfPoverty =
     yearlyImpactItems[0] &&
     isLiftPersonOutOfPovertyImpactItem(yearlyImpactItems[0]);
+  const impactItemOffset = (yearlyImpactItems.length - 1) * 24;
   const [style, setStyle] = useState({
-    transform: `translateY(-${(yearlyImpactItems.length - 1) * 24}px)`,
+    transform: `translateY(-${impactItemOffset}px)`,
     opacity: "0",
     transition: "all 1s",
   });
+  const { isConnected } = useAccount();
   useEffect(() => {
-    const fadeinTimer = setTimeout(() => {
-      setStyle({
-        ...style,
-        opacity: "1",
-      });
-    }, 500);
-    const scrollTimer = setTimeout(() => {
-      setStyle({
-        ...style,
-        opacity: "1",
-        transform: "translateY(0px)",
-      });
-    }, 1800);
+    if (isConnected) {
+      const fadeinTimer = setTimeout(() => {
+        setStyle({
+          ...style,
+          opacity: "1",
+        });
+      }, 500);
+      const scrollTimer = setTimeout(() => {
+        setStyle({
+          ...style,
+          opacity: "1",
+          transform: "translateY(0px)",
+        });
+      }, 1800);
 
-    return () => {
-      clearTimeout(fadeinTimer);
-      clearTimeout(scrollTimer);
-    };
-  }, []);
+      return () => {
+        setStyle({
+          transform: `translateY(-${impactItemOffset}px)`,
+          opacity: "0",
+          transition: "all 1s",
+        });
+        clearTimeout(fadeinTimer);
+        clearTimeout(scrollTimer);
+      };
+    }
+  }, [isConnected]);
 
   const renderImpactItemList = (impactItemList: GetImpactItem[]) =>
     yearlyImpactItems.map((item, idx) => (
@@ -47,9 +57,7 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
 
   return (
     <div className="animated-impact-list">
-      <ul className="opaque descroll" style={style}>
-        {renderImpactItemList(yearlyImpactItems)}
-      </ul>
+      <ul style={style}>{renderImpactItemList(yearlyImpactItems)}</ul>
     </div>
   );
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 
 import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
 
-import type { getImpactItem } from "@/utils";
+import type { GetImpactItem } from "@/utils";
 
 type Props = {
   yearlyYield: number;
@@ -38,7 +38,7 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
     };
   }, []);
 
-  const renderImpactItemList = (impactItemList: getImpactItem[]) =>
+  const renderImpactItemList = (impactItemList: GetImpactItem[]) =>
     yearlyImpactItems.map((item, idx) => (
       <li key={`eb-idx${idx}`}>
         {item.emoji} &#10005; {item.count}

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,21 +1,20 @@
-import {
-  getImpactItems,
-  getImpactItemList,
-  isLiftPersonOutOfPovertyImpactItem,
-} from "@/utils";
+import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
 
 type Props = {
   yearlyYield: number;
 };
 export default function EnoughToBuy({ yearlyYield }: Props) {
-  const impactItem = getImpactItemList();
-  const yearlyImpactItem = getImpactItems(yearlyYield)[0];
+  const yearlyImpactItems = getImpactItems(yearlyYield);
   const enoughToLiftPersonOutOfPoverty =
-    yearlyImpactItem && isLiftPersonOutOfPovertyImpactItem(yearlyImpactItem);
+    yearlyImpactItems[0] &&
+    isLiftPersonOutOfPovertyImpactItem(yearlyImpactItems[0]);
 
-  return (
-    <>
-      {yearlyImpactItem?.emoji} &#10005; {yearlyImpactItem?.count}
-    </>
-  );
+  const renderImpactItemList = (impactItemList) =>
+    yearlyImpactItems.map((item, idx) => (
+      <li key={`eb-idx${idx}`}>
+        {item.emoji} &#10005; {item.count}
+      </li>
+    ));
+
+  return <ul>{renderImpactItemList(yearlyImpactItems)}</ul>;
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,3 +1,4 @@
+import { motion, useAnimate, stagger } from "framer-motion";
 import { useState, useEffect } from "react";
 import { useAccount } from "wagmi";
 
@@ -13,38 +14,17 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const enoughToLiftPersonOutOfPoverty =
     yearlyImpactItems[0] &&
     isLiftPersonOutOfPovertyImpactItem(yearlyImpactItems[0]);
-  const impactItemOffset = (yearlyImpactItems.length - 1) * 24;
-  const [style, setStyle] = useState({
-    transform: `translateY(-${impactItemOffset}px)`,
-    opacity: "0",
-    transition: "all 1s",
-  });
+  const impactItemOffset = (yearlyImpactItems.length - 1) * -24;
+  const [scope, animate] = useAnimate();
   const { isConnected } = useAccount();
+
   useEffect(() => {
     if (isConnected) {
-      const fadeinTimer = setTimeout(() => {
-        setStyle({
-          ...style,
-          opacity: "1",
-        });
-      }, 500);
-      const scrollTimer = setTimeout(() => {
-        setStyle({
-          ...style,
-          opacity: "1",
-          transform: "translateY(0px)",
-        });
-      }, 1800);
-
-      return () => {
-        setStyle({
-          transform: `translateY(-${impactItemOffset}px)`,
-          opacity: "0",
-          transition: "all 1s",
-        });
-        clearTimeout(fadeinTimer);
-        clearTimeout(scrollTimer);
+      const animation = async () => {
+        await animate("ul", { opacity: 1 }, { duration: 1, delay: 0.5 });
+        animate("ul", { y: "0px" }, { duration: 1 });
       };
+      animation();
     }
   }, [isConnected]);
 
@@ -56,8 +36,10 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
     ));
 
   return (
-    <div className="animated-impact-list">
-      <ul style={style}>{renderImpactItemList(yearlyImpactItems)}</ul>
+    <div ref={scope} className="animated-impact-list">
+      <motion.ul initial={{ y: `${impactItemOffset}px`, opacity: "0" }}>
+        {renderImpactItemList(yearlyImpactItems)}
+      </motion.ul>
     </div>
   );
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,4 +1,4 @@
-import { motion, useAnimate, stagger } from "framer-motion";
+import { motion, useAnimate } from "framer-motion";
 import { useState, useEffect } from "react";
 import { useAccount } from "wagmi";
 
@@ -17,13 +17,12 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const impactItemOffset = (yearlyImpactItems.length - 1) * -24;
   const [scope, animate] = useAnimate();
   const { isConnected } = useAccount();
-  const animation = async () => {
-    await animate("ul", { opacity: 1 }, { duration: 1 });
-    animate("ul", { y: "0px" }, { duration: 1.5, ease: "easeInOut" });
-  };
-
   useEffect(() => {
     if (isConnected) {
+      const animation = async () => {
+        await animate("ul", { opacity: 1 }, { duration: 1 });
+        animate("ul", { y: "0px" }, { duration: 1.25, ease: "easeInOut" });
+      };
       animation();
     }
   }, [isConnected]);
@@ -37,12 +36,11 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
 
   return (
     <div ref={scope} className="animated-impact-list">
-      <motion.ul
-        initial={{ y: `${impactItemOffset}px`, opacity: "0" }}
-        style={{ y: `${impactItemOffset}px`, opacity: "0" }}
-      >
-        {renderImpactItemList(yearlyImpactItems)}
-      </motion.ul>
+      {isConnected && (
+        <motion.ul initial={{ y: `${impactItemOffset}px`, opacity: "0" }}>
+          {renderImpactItemList(yearlyImpactItems)}
+        </motion.ul>
+      )}
     </div>
   );
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -16,5 +16,9 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
       </li>
     ));
 
-  return <ul>{renderImpactItemList(yearlyImpactItems)}</ul>;
+  return (
+    <ul className="animated-impact-list">
+      {renderImpactItemList(yearlyImpactItems)}
+    </ul>
+  );
 }

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+
 import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
 
 type Props = {
@@ -8,6 +10,33 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const enoughToLiftPersonOutOfPoverty =
     yearlyImpactItems[0] &&
     isLiftPersonOutOfPovertyImpactItem(yearlyImpactItems[0]);
+  const [fadein, setFadein] = useState(false);
+  const [scroll, setScroll] = useState(false);
+  const [style, setStyle] = useState({
+    transform: `translateY(-${(yearlyImpactItems.length - 1) * 24}px)`,
+    opacity: "0",
+    transition: "all 1s",
+  });
+  useEffect(() => {
+    const fadeinTimer = setTimeout(() => {
+      setStyle({
+        ...style,
+        opacity: "1",
+      });
+    }, 500);
+    const scrollTimer = setTimeout(() => {
+      setStyle({
+        ...style,
+        opacity: "1",
+        transform: "translateY(0px)",
+      });
+    }, 1500);
+
+    return () => {
+      clearTimeout(fadeinTimer);
+      clearTimeout(scrollTimer);
+    };
+  }, []);
 
   const renderImpactItemList = (impactItemList) =>
     yearlyImpactItems.map((item, idx) => (
@@ -18,11 +47,7 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
 
   return (
     <div className="animated-impact-list">
-      <ul
-        style={{
-          transform: `translateY(-${(yearlyImpactItems.length - 1) * 24}px)`,
-        }}
-      >
+      <ul className="opaque descroll" style={style}>
         {renderImpactItemList(yearlyImpactItems)}
       </ul>
     </div>

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -37,7 +37,10 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
 
   return (
     <div ref={scope} className="animated-impact-list">
-      <motion.ul initial={{ y: `${impactItemOffset}px`, opacity: "0" }}>
+      <motion.ul
+        initial={{ y: `${impactItemOffset}px`, opacity: "0" }}
+        style={{ y: `${impactItemOffset}px`, opacity: "0" }}
+      >
         {renderImpactItemList(yearlyImpactItems)}
       </motion.ul>
     </div>

--- a/components/EnoughToBuy.tsx
+++ b/components/EnoughToBuy.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 
 import { getImpactItems, isLiftPersonOutOfPovertyImpactItem } from "@/utils";
 
+import type { getImpactItem } from "@/utils";
+
 type Props = {
   yearlyYield: number;
 };
@@ -10,8 +12,6 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
   const enoughToLiftPersonOutOfPoverty =
     yearlyImpactItems[0] &&
     isLiftPersonOutOfPovertyImpactItem(yearlyImpactItems[0]);
-  const [fadein, setFadein] = useState(false);
-  const [scroll, setScroll] = useState(false);
   const [style, setStyle] = useState({
     transform: `translateY(-${(yearlyImpactItems.length - 1) * 24}px)`,
     opacity: "0",
@@ -38,7 +38,7 @@ export default function EnoughToBuy({ yearlyYield }: Props) {
     };
   }, []);
 
-  const renderImpactItemList = (impactItemList) =>
+  const renderImpactItemList = (impactItemList: getImpactItem[]) =>
     yearlyImpactItems.map((item, idx) => (
       <li key={`eb-idx${idx}`}>
         {item.emoji} &#10005; {item.count}

--- a/components/ImpactInset.tsx
+++ b/components/ImpactInset.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+
+import BuyGloModal from "@/components/Modals/BuyGloModal";
+
+import EnoughToBuy from "./EnoughToBuy";
+
+export default function ImpactInset({
+  openModal,
+  yearlyYield,
+  yearlyYieldFormatted,
+}) {
+  return (
+    <div className="m-1">
+      <button
+        className="flex flex-col bg-impact-bg text-impact-fg rounded-[24px] px-5 pb-3 w-full font-normal items-baseline"
+        onClick={() => openModal(<BuyGloModal />)}
+      >
+        <div className="">
+          <div className="h-4 w-4 bg-white -rotate-45 transform origin-top-left translate-x-32"></div>
+        </div>
+        <div className="flex w-full justify-between items-center space-y-2">
+          <div className="flex items-center">
+            <Image
+              className="pb-[2px] mr-2"
+              src="/glo-logo.svg"
+              alt="glo"
+              height={28}
+              width={28}
+            />
+            {yearlyYieldFormatted} / year
+          </div>
+          <EnoughToBuy yearlyYield={yearlyYield} />
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/components/ImpactInset.tsx
+++ b/components/ImpactInset.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import Image from "next/image";
 import { useState, useEffect } from "react";
 
@@ -15,18 +16,6 @@ export default function ImpactInset({
   yearlyYield,
   yearlyYieldFormatted,
 }: Props) {
-  const [style, setStyle] = useState({
-    opacity: "0",
-    transition: "all 1s",
-  });
-  useEffect(() => {
-    const fadeinTimer = setTimeout(() => {
-      setStyle({
-        ...style,
-        opacity: "1",
-      });
-    }, 500);
-  }, []);
   return (
     <div className="m-1">
       <button
@@ -37,7 +26,12 @@ export default function ImpactInset({
           <div className="h-4 w-4 bg-white -rotate-45 transform origin-top-left translate-x-32"></div>
         </div>
         <div className="flex w-full justify-between items-center space-y-2">
-          <div className="flex items-center" style={style}>
+          <motion.div
+            className="flex items-center"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 1 }}
+          >
             <Image
               className="pb-[2px] mr-2"
               src="/glo-logo.svg"
@@ -46,7 +40,7 @@ export default function ImpactInset({
               width={28}
             />
             {yearlyYieldFormatted} / year
-          </div>
+          </motion.div>
           <EnoughToBuy yearlyYield={yearlyYield} />
         </div>
       </button>

--- a/components/ImpactInset.tsx
+++ b/components/ImpactInset.tsx
@@ -5,11 +5,16 @@ import BuyGloModal from "@/components/Modals/BuyGloModal";
 
 import EnoughToBuy from "./EnoughToBuy";
 
+type Props = {
+  openModal: any;
+  yearlyYield: number;
+  yearlyYieldFormatted: string;
+};
 export default function ImpactInset({
   openModal,
   yearlyYield,
   yearlyYieldFormatted,
-}) {
+}: Props) {
   const [style, setStyle] = useState({
     opacity: "0",
     transition: "all 1s",
@@ -21,13 +26,6 @@ export default function ImpactInset({
         opacity: "1",
       });
     }, 500);
-    const scrollTimer = setTimeout(() => {
-      setStyle({
-        ...style,
-        opacity: "1",
-        transform: "translateY(0px)",
-      });
-    }, 1800);
   }, []);
   return (
     <div className="m-1">

--- a/components/ImpactInset.tsx
+++ b/components/ImpactInset.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useState, useEffect } from "react";
 
 import BuyGloModal from "@/components/Modals/BuyGloModal";
 
@@ -9,6 +10,25 @@ export default function ImpactInset({
   yearlyYield,
   yearlyYieldFormatted,
 }) {
+  const [style, setStyle] = useState({
+    opacity: "0",
+    transition: "all 1s",
+  });
+  useEffect(() => {
+    const fadeinTimer = setTimeout(() => {
+      setStyle({
+        ...style,
+        opacity: "1",
+      });
+    }, 500);
+    const scrollTimer = setTimeout(() => {
+      setStyle({
+        ...style,
+        opacity: "1",
+        transform: "translateY(0px)",
+      });
+    }, 1800);
+  }, []);
   return (
     <div className="m-1">
       <button
@@ -19,7 +39,7 @@ export default function ImpactInset({
           <div className="h-4 w-4 bg-white -rotate-45 transform origin-top-left translate-x-32"></div>
         </div>
         <div className="flex w-full justify-between items-center space-y-2">
-          <div className="flex items-center">
+          <div className="flex items-center" style={style}>
             <Image
               className="pb-[2px] mr-2"
               src="/glo-logo.svg"

--- a/components/Modals/AllTransactionsModal.tsx
+++ b/components/Modals/AllTransactionsModal.tsx
@@ -6,7 +6,7 @@ import { ModalContext } from "@/lib/context";
 import { useUserStore } from "@/lib/store";
 import { api } from "@/lib/utils";
 
-import { TransactionsList } from "../TransactionsList";
+import TransactionsList from "../TransactionsList";
 
 export default function AllTransactionsModal() {
   const { chain } = useNetwork();

--- a/components/Transactions.tsx
+++ b/components/Transactions.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import { useEffect, useState, useContext } from "react";
-import { useAccount, useNetwork } from "wagmi";
-import { useConnect } from "wagmi";
+import { useAccount, useConnect, useNetwork } from "wagmi";
 
 import BuyGloModal from "@/components/Modals/BuyGloModal";
 import { ModalContext } from "@/lib/context";
@@ -44,45 +43,53 @@ export default function Transactions() {
           )}
         </button>
       </div>
-      {dropdown === "list-item" && transfers.length ? (
-        <ul className={`mt-12 ${dropdown}`}>
-          <TransactionsList txns={transfers.slice(0, 5)} />
-          {transfersCursor && (
-            <li
-              onClick={() => openModal(<AllTransactionsModal />)}
-              className="underline cursor-pointer"
+      <div
+        className={`${
+          isConnected && !transfers.length
+            ? "mt-6 max-h-6 opacity-100"
+            : "max-h-0 invisible opacity-0"
+        }
+        text-sm transition-all duration-500`}
+      >
+        <span> No transactions yet - </span>
+        <button
+          className="inline cursor-pointer hover:decoration-solid text-blue-500"
+          onClick={() => openModal(<BuyGloModal />)}
+        >
+          buy some Glo?
+        </button>
+      </div>
+      <ul
+        className={`${
+          dropdown === "list-item" && transfers.length
+            ? "max-h-[414px] mt-12 opacity-100"
+            : "max-h-0 invisible opacity-0"
+        }
+        transition-all duration-500`}
+      >
+        <TransactionsList txns={transfers.slice(0, 5)} />
+        {transfersCursor && (
+          <li
+            onClick={() => openModal(<AllTransactionsModal />)}
+            className="underline cursor-pointer"
+          >
+            View all transactions
+          </li>
+        )}
+      </ul>
+      <>
+        {!isConnected && (
+          <div className="mt-3 text-sm">
+            <span> No transactions to show - </span>
+            <button
+              className="inline cursor-pointer hover:decoration-solid text-blue-500"
+              onClick={() => openModal(<UserAuthModal />, "bg-transparent")}
             >
-              View all transactions
-            </li>
-          )}
-        </ul>
-      ) : (
-        <>
-          {!isConnected && (
-            <div className="mt-3 text-sm">
-              <span> No transactions to show - </span>
-              <button
-                className="inline cursor-pointer hover:decoration-solid text-blue-500"
-                onClick={() => openModal(<UserAuthModal />, "bg-transparent")}
-              >
-                please log in
-              </button>
-            </div>
-          )}
-
-          {isConnected && !transfers.length && (
-            <div className="mt-6 text-sm">
-              <span> No transactions yet - </span>
-              <button
-                className="inline cursor-pointer hover:decoration-solid text-blue-500"
-                onClick={() => openModal(<BuyGloModal />)}
-              >
-                buy some Glo?
-              </button>
-            </div>
-          )}
-        </>
-      )}
+              please log in
+            </button>
+          </div>
+        )}
+      </>
     </div>
   );
 }

--- a/components/Transactions.tsx
+++ b/components/Transactions.tsx
@@ -1,3 +1,4 @@
+import { stagger, motion, animate, useCycle } from "framer-motion";
 import Image from "next/image";
 import { useEffect, useState, useContext } from "react";
 import { useAccount, useConnect, useNetwork } from "wagmi";
@@ -8,26 +9,35 @@ import { useUserStore } from "@/lib/store";
 
 import AllTransactionsModal from "./Modals/AllTransactionsModal";
 import UserAuthModal from "./Modals/UserAuthModal";
-import { TransactionsList } from "./TransactionsList";
+import TransactionsList from "./TransactionsList";
 
 export default function Transactions() {
   const { transfers, transfersCursor } = useUserStore();
   const { connect, connectors } = useConnect();
   const { address, isConnected } = useAccount();
   const { chain } = useNetwork();
-  const [dropdown, setDropdown] = useState("hidden");
-  const [caretDir, setCaretDir] = useState("down");
   const { openModal } = useContext(ModalContext);
 
-  const toggleDropdown = () => {
-    dropdown === "list-item" ? setDropdown("hidden") : setDropdown("list-item");
-    caretDir === "up" ? setCaretDir("down") : setCaretDir("up");
+  const [isOpen, toggleOpen] = useCycle(false, true);
+
+  const variants = {
+    open: {
+      transition: { staggerChildren: 0.07, delayChildren: 0.2 },
+      height: "426px",
+      margin: "24px 0 0 0",
+    },
+    closed: {
+      transition: { staggerChildren: 0.05, staggerDirection: -1, delay: 0.2 },
+      height: "0px",
+    },
   };
 
   return (
-    <div
-      className="bg-white rounded-[20px] p-8 transition-all"
-      onClick={toggleDropdown}
+    <motion.div
+      className="bg-white rounded-[20px] p-8"
+      animate={isOpen ? "open" : "closed"}
+      initial={false}
+      onClick={() => transfers?.length && toggleOpen()}
     >
       <div className="flex justify-between cursor-default">
         <h3>Transactions</h3>
@@ -35,7 +45,7 @@ export default function Transactions() {
           {isConnected && (
             <Image
               className="cursor-pointer"
-              src={`/${caretDir}-caret.svg`}
+              src={`/${isOpen ? "up" : "down"}-caret.svg`}
               width={14}
               height={14}
               alt="down-arrow"
@@ -49,7 +59,7 @@ export default function Transactions() {
             ? "mt-6 max-h-6 opacity-100"
             : "max-h-0 invisible opacity-0"
         }
-        text-sm transition-all duration-500`}
+        text-sm `}
       >
         <span> No transactions yet - </span>
         <button
@@ -59,25 +69,21 @@ export default function Transactions() {
           buy some Glo?
         </button>
       </div>
-      <ul
-        className={`${
-          dropdown === "list-item" && transfers.length
-            ? "max-h-[414px] mt-12 opacity-100"
-            : "max-h-0 invisible opacity-0"
-        }
-        transition-all duration-500`}
-      >
-        <TransactionsList txns={transfers.slice(0, 5)} />
+      <motion.ul variants={variants}>
+        <TransactionsList
+          txns={transfers.slice(0, 5)}
+          transfersCursor={transfersCursor}
+        />
         {transfersCursor && (
-          <li
+          <motion.li
             onClick={() => openModal(<AllTransactionsModal />)}
             className="underline cursor-pointer"
           >
             View all transactions
-          </li>
+          </motion.li>
         )}
-      </ul>
-      <>
+      </motion.ul>
+      <div>
         {!isConnected && (
           <div className="mt-3 text-sm">
             <span> No transactions to show - </span>
@@ -89,7 +95,7 @@ export default function Transactions() {
             </button>
           </div>
         )}
-      </>
-    </div>
+      </div>
+    </motion.div>
   );
 }

--- a/components/Transactions.tsx
+++ b/components/Transactions.tsx
@@ -70,10 +70,7 @@ export default function Transactions() {
         </button>
       </div>
       <motion.ul variants={variants}>
-        <TransactionsList
-          txns={transfers.slice(0, 5)}
-          transfersCursor={transfersCursor}
-        />
+        <TransactionsList txns={transfers.slice(0, 5)} />
         {transfersCursor && (
           <motion.li
             onClick={() => openModal(<AllTransactionsModal />)}

--- a/components/TransactionsList.tsx
+++ b/components/TransactionsList.tsx
@@ -14,7 +14,7 @@ export default function TransactionsList({ txns }: { txns: Transfer[] }) {
     },
   };
 
-  const renderTxns = (txns: Transfer[], transfersCursor: any) =>
+  const renderTxns = (txns: Transfer[]) =>
     txns.map((txn, idx) => {
       const dateTokens = new Date(txn.ts).toDateString().split(" ");
       const txnDate = dateTokens[1] + " " + dateTokens[2];

--- a/components/TransactionsList.tsx
+++ b/components/TransactionsList.tsx
@@ -1,10 +1,29 @@
-export const TransactionsList = ({ txns }: { txns: Transfer[] }) => (
-  <>
-    {txns.map((txn, idx) => {
+import { motion } from "framer-motion";
+
+export default function TransactionsList({ txns }: { txns: Transfer[] }) {
+  const variants = {
+    open: {
+      x: 0,
+      opacity: 1,
+      transition: { y: { stiffness: 1000, velocity: -100 } },
+    },
+    closed: {
+      x: 50,
+      opacity: 0,
+      transition: { y: { stiffness: 1000 } },
+    },
+  };
+
+  const renderTxns = (txns: Transfer[], transfersCursor: any) =>
+    txns.map((txn, idx) => {
       const dateTokens = new Date(txn.ts).toDateString().split(" ");
       const txnDate = dateTokens[1] + " " + dateTokens[2];
       return (
-        <li key={`txn-${idx}`} className="transaction-item">
+        <motion.li
+          key={`txn-${idx}`}
+          className="transaction-item"
+          variants={variants}
+        >
           <div>
             <p>
               {txn.type === "outgoing" ? "Sent to " : "Received from"}{" "}
@@ -23,8 +42,8 @@ export const TransactionsList = ({ txns }: { txns: Transfer[] }) => (
               </span>
             </b>
           </div>
-        </li>
+        </motion.li>
       );
-    })}
-  </>
-);
+    });
+  return <>{renderTxns(txns)}</>;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -106,4 +106,8 @@ body {
   .react-modal-sheet-container {
     @apply shadow-xl !important;
   }
+
+  .animated-impact-list {
+    @apply m-0 h-[24px] overflow-hidden !important;
+  }
 }

--- a/utils.ts
+++ b/utils.ts
@@ -95,8 +95,6 @@ export const getImpactItems = (amount: number): GetImpactItem[] => {
   return impactItems;
 };
 
-export const getImpactItemList = (): GetImpactItem[] => possibleImpactItems;
-
 export const isLiftPersonOutOfPovertyImpactItem = (
   impactItem: GetImpactItem
 ): boolean => {

--- a/utils.ts
+++ b/utils.ts
@@ -10,89 +10,92 @@ export const getTotalYield = (amount: number): number => {
   return (amount * ANNUAL_INTEREST_RATE * TOTAL_DAYS) / 365;
 };
 
+// descending order of cost
+// multiplying every item by 1.11 because givedirectly is only 90% efficient with the yield received
+const possibleImpactItems = [
+  {
+    description: "20 litres of water",
+    cost: 0.03 * 1.11,
+    emoji: "🚰",
+  },
+  {
+    description: "kg of maize",
+    cost: 0.95 * 1.11,
+    emoji: "🌽",
+  },
+  {
+    description: "School textbook",
+    cost: 1.22 * 1.11,
+    emoji: "📚",
+  },
+  {
+    description: "School uniform",
+    cost: 3.24 * 1.11,
+    emoji: "🧑‍🏫",
+  },
+  {
+    description: "Kienyeji farm chicken",
+    cost: 12 * 1.11,
+    emoji: "🐔",
+  },
+  {
+    description: "Fishing net",
+    cost: 100 * 1.11,
+    emoji: "🎣",
+  },
+  {
+    description: "Saanen dairy goat",
+    cost: 121 * 1.11,
+    emoji: "🐐",
+  },
+  {
+    description: "Inventory to start a kiosk",
+    cost: 162 * 1.11,
+    emoji: "🏪",
+  },
+  {
+    description: "Dairy cow",
+    cost: 200 * 1.11,
+    emoji: "🐄",
+  },
+  {
+    description: "House building materials",
+    cost: 227 * 1.11,
+    emoji: "🧱",
+  },
+  {
+    description: "80 m² of farm land",
+    cost: 300 * 1.11,
+    emoji: "🌱",
+  },
+  {
+    description: "Person out of extreme poverty",
+    // 480 already takes into account givedirectly inefficiency figure
+    cost: 480,
+    emoji: "🧑",
+  },
+].sort((item1, item2) => item2.cost - item1.cost);
+
 export interface GetImpactItem {
   description: string;
   cost: number;
-  count: number;
   emoji: string;
+  count?: number;
+  idx?: number;
 }
 export const getImpactItems = (amount: number): GetImpactItem[] => {
-  // descending order of cost
-  // multiplying every item by 1.11 because givedirectly is only 90% efficient with the yield received
-  const possibleImpactItems = [
-    {
-      description: "20 litres of water",
-      cost: 0.03 * 1.11,
-      emoji: "🚰",
-    },
-    {
-      description: "kg of maize",
-      cost: 0.95 * 1.11,
-      emoji: "🌽",
-    },
-    {
-      description: "School textbook",
-      cost: 1.22 * 1.11,
-      emoji: "📚",
-    },
-    {
-      description: "School uniform",
-      cost: 3.24 * 1.11,
-      emoji: "🧑‍🏫",
-    },
-    {
-      description: "Kienyeji farm chicken",
-      cost: 12 * 1.11,
-      emoji: "🐔",
-    },
-    {
-      description: "Fishing net",
-      cost: 100 * 1.11,
-      emoji: "🎣",
-    },
-    {
-      description: "Saanen dairy goat",
-      cost: 121 * 1.11,
-      emoji: "🐐",
-    },
-    {
-      description: "Inventory to start a kiosk",
-      cost: 162 * 1.11,
-      emoji: "🏪",
-    },
-    {
-      description: "Dairy cow",
-      cost: 200 * 1.11,
-      emoji: "🐄",
-    },
-    {
-      description: "House building materials",
-      cost: 227 * 1.11,
-      emoji: "🧱",
-    },
-    {
-      description: "80 m² of farm land",
-      cost: 300 * 1.11,
-      emoji: "🌱",
-    },
-    {
-      description: "Person out of extreme poverty",
-      // 480 already takes into account givedirectly inefficiency figure
-      cost: 480,
-      emoji: "🧑",
-    },
-  ].sort((item1, item2) => item2.cost - item1.cost);
-
   const impactItems = [];
   for (let idx = 0; amount > 0 && idx < possibleImpactItems.length; idx++) {
     const possibleImpactItem = possibleImpactItems[idx];
     if (amount >= possibleImpactItem.cost) {
       const itemCount = Math.floor(amount / possibleImpactItem.cost);
-      impactItems.push({ ...possibleImpactItem, count: itemCount });
+      impactItems.push({ ...possibleImpactItem, count: itemCount, idx: idx });
     }
   }
   return impactItems;
 };
+
+export const getImpactItemList = (): GetImpactItem[] => possibleImpactItems;
 
 export const isLiftPersonOutOfPovertyImpactItem = (
   impactItem: GetImpactItem


### PR DESCRIPTION
resolves #56 

negative transform translations aren't working in tailwind so I had to hack it a bit with manual transitions.

I added state transitions as well for transactions list height. I had height transitions for the impact inset and balance but I think it looks too "squishy". I have it locally so I can push if you want to see

there is a flash of state where the transfer doesn't populate immediately and we show the empty list prompt, but I don't want to bloat this PR.

I'm not a fan of the spinny glo logo in the impact inset, feels needlessly distracting/draws the eye unnecessarily. open to thoughts on spinning the logo in the top