### PR TITLE
Restyle swappable USDC so it's slightly less in your face

### DIFF
--- a/components/Balance.tsx
+++ b/components/Balance.tsx
@@ -111,7 +111,7 @@ export default function Balance({
         </div>
         {usdcBalance && usdcBalance.value > 0 && (
           <a
-            className="black-link self-center"
+            className="text-pine-700 self-center"
             onClick={() => {
               openModal(
                 <BuyWithCoinbaseSequenceModal
@@ -120,7 +120,8 @@ export default function Balance({
               );
             }}
           >
-            ({formattedUSDC} USDC swappable for Glo Dollar)
+            <span className="black-link">{formattedUSDC} USDC</span>{" "}
+            <span className="invisible-link">swappable for Glo Dollar</span>
           </a>
         )}
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -127,4 +127,8 @@ body {
   .black-link {
     @apply cursor-pointer underline !important;
   }
+
+  .invisible-link {
+    @apply cursor-pointer !important;
+  }
 }


### PR DESCRIPTION
New style:
<img width="373" alt="image" src="https://github.com/Glo-Foundation/glo-wallet/assets/1226415/0e020f07-63df-4ae6-b0f8-113062e14484">


Old style:
<img width="472" alt="image" src="https://github.com/Glo-Foundation/glo-wallet/assets/1226415/fbb38794-79d5-42ff-81e0-882c11bf4170">
