### PR TITLE
add right padding to email input

### DIFF
--- a/components/Modals/UserAuthModal.tsx
+++ b/components/Modals/UserAuthModal.tsx
@@ -125,7 +125,7 @@ export default function UserAuthModal() {
             <div className="input-container relative inline w-full">
               <input
                 id="sign-in-with-email"
-                className="rounded-full bg-white py-4 px-6 text-xl"
+                className="rounded-full bg-white py-4 pl-6 pr-28 text-xl"
                 placeholder={"Email"}
                 value={sendForm.email}
                 data-testid="submit-email-input"


### PR DESCRIPTION
Email input now looks like

<img width="470" alt="image" src="https://github.com/Glo-Foundation/glo-wallet/assets/1057844/4ab134df-6374-4042-9267-89e317ed8235">
