### PR TITLE
Add sell options to the app

### DIFF
--- a/components/Modals/BoxBuyModal.tsx
+++ b/components/Modals/BoxBuyModal.tsx
@@ -57,6 +57,20 @@ export default function BoxBuyModal({
       </div>
       <h2 className="text-center pt-0">Buy Glo Dollars</h2>
       {children}
+      <div className="flex flex-col space-y-2 mt-4">
+        <button
+          className="bg-cyan-600 text-pine-900 h-[52px] py-3.5 mx-6"
+          onClick={() => window.open("https://peanut.to/cashout", "_blank")}
+        >
+          Sell for wire to US/CAD/EU bank accounts
+        </button>
+        <button
+          className="bg-cyan-600 text-pine-900 h-[52px] py-3.5 mx-6"
+          onClick={() => window.open("https://www.offramp.xyz/", "_blank")}
+        >
+          Sell for card in 160+ countries
+        </button>
+      </div>
     </div>
   );
 }

--- a/components/Modals/SquidModal.tsx
+++ b/components/Modals/SquidModal.tsx
@@ -59,6 +59,20 @@ export default function SquidModal({}: Props) {
           }}
         />
       </section>
+      <div className="flex flex-col space-y-2 mt-4">
+        <button
+          className="bg-cyan-600 text-pine-900 h-[52px] py-3.5 mx-6"
+          onClick={() => window.open("https://peanut.to/cashout", "_blank")}
+        >
+          Sell for wire to US/CAD/EU bank accounts
+        </button>
+        <button
+          className="bg-cyan-600 text-pine-900 h-[52px] py-3.5 mx-6"
+          onClick={() => window.open("https://www.offramp.xyz/", "_blank")}
+        >
+          Sell for card in 160+ countries
+        </button>
+      </div>
     </div>
   );
 }

--- a/components/Modals/SwapGate.tsx
+++ b/components/Modals/SwapGate.tsx
@@ -92,6 +92,24 @@ export default function SwapGate(props: Props) {
         delay="⚡ Instant"
         onClick={() => openModal(<SquidModal buyAmount={buyAmount} />)}
       />
+      <BuyBox
+        key="peanut"
+        name="Peanut"
+        icon="/peanut.png"
+        fees="0.5"
+        worksFor="💳 Card"
+        delay="⚡ Instant"
+        onClick={() => window.open("https://peanut.to/cashout", "_blank")}
+      />
+      <BuyBox
+        key="offramp"
+        name="Offramp"
+        icon="/offramp.png"
+        fees="0.5"
+        worksFor="💳 Card"
+        delay="⚡ Instant"
+        onClick={() => window.open("https://www.offramp.xyz/", "_blank")}
+      />
     </BoxBuyModal>
   );
 }

--- a/components/Modals/SwapModal.tsx
+++ b/components/Modals/SwapModal.tsx
@@ -157,6 +157,20 @@ export default function SwapModal({ buyAmount }: Props) {
               USDC={usdcBalance?.formatted}
             />
           )}
+          <StepCard
+            index={3}
+            iconPath="/peanut.png"
+            title="Sell USDGLO for wire to US/CAD/EU bank accounts"
+            content={"Sell with Peanut.to"}
+            action={() => window.open("https://peanut.to/cashout", "_blank")}
+          />
+          <StepCard
+            index={4}
+            iconPath="/offramp.png"
+            title="Sell USDGLO for card in 160+ countries"
+            content={"Sell with Offramp.xyz"}
+            action={() => window.open("https://www.offramp.xyz/", "_blank")}
+          />
         </section>
       )}
     </div>


### PR DESCRIPTION
Fixes #460

Add sell options for wire to US/CAD/EU bank accounts and card in 160+ countries.

* Add `BuyBox` components for `peanut.to` and `offramp.xyz` in `components/Modals/SwapGate.tsx`.
* Add `StepCard` components for `peanut.to` and `offramp.xyz` in `components/Modals/SwapModal.tsx`.
* Add buttons for `peanut.to` and `offramp.xyz` in `components/Modals/BoxBuyModal.tsx`.
* Add buttons for `peanut.to` and `offramp.xyz` in `components/Modals/SquidModal.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Glo-Foundation/glo-wallet/pull/471?shareId=d5fc34d6-7d87-465d-bd0b-aaad880d68fd).